### PR TITLE
Fixed Server.scala to use the configured port

### DIFF
--- a/src/main/scala/io/scalac/akka/http/websockets/Server.scala
+++ b/src/main/scala/io/scalac/akka/http/websockets/Server.scala
@@ -42,7 +42,7 @@ object Server extends App {
   private def alternativelyRunTheClient(): Unit = {
 
     if (args.head.equalsIgnoreCase("with-client")) {
-      val c: WSClient = WSClient("http://localhost:8080/ws-chat/123?name=HAL1000", "HAL1000")
+      val c: WSClient = WSClient(s"http://localhost:${port}/ws-chat/123?name=HAL1000", "HAL1000")
 
       if (c.connectBlocking())
         c.spam("hello message")


### PR DESCRIPTION
When the `with-client` command line option is used and a non default port were set in the src/main/resources/application.conf then the client can not connect to the server.

So: simply change hardcoded 8080 to the already available "port" variable

```
  val c: WSClient = WSClient(s"http://localhost:${port}/ws-chat/123?name=HAL1000", "HAL1000")
```
