### PR TITLE
fix throwing an exception when started with no arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,5 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 
-
+target
+project/target

--- a/src/main/scala/io/scalac/akka/http/websockets/Server.scala
+++ b/src/main/scala/io/scalac/akka/http/websockets/Server.scala
@@ -41,7 +41,7 @@ object Server extends App {
 
   private def alternativelyRunTheClient(): Unit = {
 
-    if (args.head.equalsIgnoreCase("with-client")) {
+    if (args.headOption.map(_.equalsIgnoreCase("with-client")).getOrElse(false)) {
       val c: WSClient = WSClient("http://localhost:8080/ws-chat/123?name=HAL1000", "HAL1000")
 
       if (c.connectBlocking())


### PR DESCRIPTION
When started with just `sbt run` it was throwing:

```
[error] (run-main-0) java.util.NoSuchElementException: next on empty iterator
java.util.NoSuchElementException: next on empty iterator
```

This PR fixes that
